### PR TITLE
Fixed some errors in some MIPS assembly files

### DIFF
--- a/arrays.s
+++ b/arrays.s
@@ -16,12 +16,17 @@
 #
 # Karl Marklund <karl.marklund@it.uu.se>
 #
+# Zhang Runmin <fmrt19zrmin@163.com>
 #
 # HISTORY
 #
 # 2015-12-10
 #
 # First version.
+# 
+# 2023-04-18
+#
+# Second version.
 # ---------------------------------------------------------------------------
 
 
@@ -34,19 +39,19 @@
 
 	.data
 
-# Store three consequtive 4 byte words in memory.
+# Store three consecutive 4 byte words in memory.
 
 int_array:  .word 10, 11, 12
 
-# Three stirngs. Each label is an address (pointer) to a null terminated string.
+# Three strings. Each label is an address (pointer) to a null terminated string.
 
 one:	.asciiz "One\n"
 two: 	.asciiz "Two\n"
 three:	.asciiz "Three\n"
 
-# Here each value in str_array is a label that gets replaced by the label
-# address by the assembler. Each such label is a address (pointer) to a
-# null terminated string. Hence this is an array of pointer to strings, that is,
+# Here each value in str_array is a label that gets replaced by the label address 
+# by the assembler. Each such label is an address, a.k.a. a pointer to a null 
+# terminated string. Hence this is an array of pointer to strings, that is, 
 # an array of strings.
 
 str_array: .word one, two, three

--- a/basics.s
+++ b/basics.s
@@ -30,22 +30,26 @@
 #   Directive	Description
 #   ----------------------------------------------------------------------
 #   .data	Subsequent items are stored in the data segment.
-#   .text	Subsequent items are put in the user text seg- ment.
+#   .text	Subsequent items are put in the user text segment.
 #   .space	Allocate n bytes of space in the current segment.
 #   .word n	Store the integer n as 4 byte word in the current segment.
-#   .asciiz	Store the string str in memory and null-termi- nate it.
+#   .asciiz	Store the string str in memory and null-terminate it.
 #
 #
 # AUTHOR
 #
 # Karl Marklund <karl.marklund@it.uu.se>
-#
+# Zhang Runmin <fmrt19zrmin@163.com>
 #
 # HISTORY
 #
 # 2015-12-10
 #
 # First version.
+# 
+# 2023-04-18
+#
+# Second version.
 # ---------------------------------------------------------------------------
 
 
@@ -96,12 +100,12 @@ main:
 	
 	# To store a value in a register, the li instruction can be used.
 
-	# Here the immediate value 5 i loaded into register $t0.
+	# Here the immediate value 5 is loaded into register $t0.
 
 	li $t0, 5
 
 	# Note that li is a pseudo instruction that gets translated to a addiu
-	# (Add Immediate Unsigned) instruction by the assemblator.
+	# (Add Immediate Unsigned) instruction by the assembler.
 
 	#####
 	##### la - Load Address
@@ -113,11 +117,11 @@ main:
 
 	la $t1, x
 
-	# NOTE: la is a pseudo instruction that the assemblator translates to
+	# NOTE: la is a pseudo instruction that the assembler translates to
 	# two instructions:
 	#
-	# One lui (Load Upper Immediate) instruction setting $ta (address translate).
-	#
+	# One lui (Load Upper Immediate) instruction setting $at (address translate). 
+	# 
 	# One ori (OR Immediate) storing the memory address of the label in register
 	# $t1.
 
@@ -144,7 +148,7 @@ main:
 	
 	lw $t3, x
 
-	# NOTE: when using the above adressing mode (label) the assemblator
+	# NOTE: when using the above adressing mode (label) the assembler
 	# translates the single lw instruction to two instructions:
 	#
 	# One lui (Load Upper Immediate) instruction storing the memory address of
@@ -198,13 +202,13 @@ main:
 
 	sw $t5, z
 
-	# NOTE: when using the above adressing mode (label) the assemblator
+	# NOTE: when using the above adressing mode (label) the assembler
 	# translates the single lw instruction to two instructions:
 	#
 	# One lui (Load Upper Immediate) instruction storing the memory address of
 	# the label in register $at (address translation register).
 	#
-	# One lw instruction with  address mode c(rx), which uses the sum of the
+	# One sw instruction with  address mode c(rx), which uses the sum of the
 	# immediate c and register rx as the address.
 
 	#####
@@ -219,7 +223,7 @@ main:
 	move $t6, $t5
 
 	#####
-	##### print_string (system call(
+	##### print_string (system call)
 	#####
 
 	# Set system call code 4 (print_string) in regsiter $v0.
@@ -244,11 +248,11 @@ main:
 
 	# Load value to print in register $a0.
 
-	# Can use li to print immediate value.
+	# Can use li to load immediate value.
 
 	li $a0, 127
 
-	# NOTE: system call code already set to 1 (print_int) in $a0.
+	# NOTE: system call code already set to 1 (print_int) in $v0.
 
 	# Use the syscall instruction to print the integer.
 

--- a/jump_and_branches.s
+++ b/jump_and_branches.s
@@ -28,12 +28,17 @@
 #
 # Karl Marklund <karl.marklund@it.uu.se>
 #
+# Zhang Runmin <fmrt19zrmin@163.com>
 #
 # HISTORY
 #
 # 2015-12-10
 #
 # First version.
+#
+# 2023-04-18
+#
+# Second version.
 # ---------------------------------------------------------------------------
 
 
@@ -61,7 +66,7 @@ main:
 
 	# Execution starts at the label main.
 
-	addi $s0, $s0, 0 	# Initialize $s0 = 0.
+	andi $s0, $s0, 0 	# Initialize $s0 = 0.
 
 
   	#####
@@ -106,7 +111,7 @@ increment_s1:
 	# First we need to test if $t0 < $t1 and make a decision based on the result.
 	# For this purpose we can use the blt (Branch if Less Than) instruction.
 
-	# If $t0 < $1 jump to the label less_than, othewise continue with the next
+	# If $t0 < $t1 jump to the label less_than_1, othewise continue with the next
 	# instruction.
 
 	blt $t0, $t1, less_than_1
@@ -118,7 +123,7 @@ not_less_than_1:
 	# NOTE: As a result of using blt the else case follows directly after the test.
 
 	la $a0, no	# Load the address of string to print.
-	j print_1	# Unconditionally jump to the label print.
+	j print_1	# Unconditionally jump to the label print_1.
 
 less_than_1:
 
@@ -136,7 +141,7 @@ print_1:
 	
 	# An alternative is to use the bge (Branch if Greater or Equal) instruction.
 
-	# If $t0 >= $t1 jump to label greater_or_equal, otherwise continute with the
+	# If $t0 >= $t1 jump to label not_less_than_2, otherwise continute with the
 	# next instruction.
 
 	bge $t0, $t1, not_less_than_2
@@ -179,3 +184,5 @@ loop_forever:
 	j loop_forever
 
 	# This code will never be reached.
+	li $v0, 10
+	syscall

--- a/subroutines.s
+++ b/subroutines.s
@@ -14,11 +14,17 @@
 #
 # Karl Marklund <karl.marklund@it.uu.se>
 #
+# Zhang Runmin <fmrt19zrmin@163.com>
+#
 # HISTORY
 #
 # 2018-01-14
 #
 # First version.
+#
+# 2023-04-18
+#
+# Second version.
 # ---------------------------------------------------------------------------
 
 	.data
@@ -51,7 +57,7 @@ main:
 	
 
 	# Jump to label hello and set $ra to the address of the next 
-	# instruction, i.e., the address of the li $0, 0x1234abcd instruction.
+	# instruction, i.e., the address of the li $t0, 0x1234abcd instruction.
 	
 	jal hello
 	
@@ -138,9 +144,9 @@ compute:
 # ---------------------------------------------------------------------------
 # Subroutine say_hi
 #
-# Argument(s): $a - Address to a <name> string.
+# Argument(s): $a0 - Address to a <name> string.
 #
-# Side effects: Prints "Hi <name>
+# Side effects: Prints "Hi <name>"
 # ---------------------------------------------------------------------------	
 say_hi:
 	move $t0, $a0


### PR DESCRIPTION
There's one bug in __jump_and_branches.s__ Line 64 (after I fixed, Line 69).
To initialize `$s0 = 0`, should use `andi $s0, $s0, 0`, but not `addi $s0, $s0, 0`, because the Mars initializes all registers to 0, so the instruction `addi $s0, $s0, 0` do not become a bug when you run this file, but we should better use `andi $s0, $s0, 0`.